### PR TITLE
Fix README.md config file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ The config file looks like this:
 
 ```js
 {
-    "files":
+    "files": {
         "<ElmFile.elm>": "<OutputFile.html>"
+    }
 }
 ```
 


### PR DESCRIPTION
Added missing brackets to the json example of the config file.