### PR TITLE
Improve usage messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,23 @@ which will produce
 ## Flags
 
 `elm-static-html -f Main.elm` will print the output to stdout by default
-You can create an initial config file through `elm-static-html --init`, though it's not needed to work.
+You can create an initial config file through `elm-static-html --init-config`, though it's not needed to work.
 
-You can use a config to generate files through `elm-static-html -c elm-static-html.json`.
+You can use the config file to generate multiple files through `elm-static-html -c elm-static-html.json`.
 The config file looks like this:
 
 ```js
 {
     "files": {
-        "<ElmFile.elm>": "<OutputFile.html>"
+        "<ElmFile.elm>": {
+            "output": "<OutputFile.html>",
+            "viewFunction": "view"
+        },
+        "<AnotherElmFile.elm": {
+            "output": "<AnotherOutputFile.html>",
+            "viewFunction": "someViewFunc"
+        }
+        /* ... */
     }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ var renderDirName = '.elm-static-html';
 
 var argv = yargs
     .usage('Usage: <command> [options]')
+    .version()
+    .help('h')
+    .alias('h', 'help')
     .alias('f', 'filename')
     .describe('f', 'Provide an Elm file to compile to HTML')
 
@@ -21,6 +24,7 @@ var argv = yargs
 
     .alias('v', 'verbose')
     .describe('v', 'Be more chatty')
+    .default('v', false)
 
     .alias('c', 'config')
     .describe('c', 'Provide a json file for use as config')
@@ -48,7 +52,7 @@ var standardizedConfig = function(config){
     return config;
 };
 
-const isVerbose = (typeof argv.v !== "undefined" && argv.v);
+const isVerbose = argv.verbose;
 const isInitConfig = (typeof argv.initConfig !== "undefined" && argv.initConfig);
 const outputToStdOut = (typeof argv.o === "undefined");
 const isUsingConfig = (typeof argv.c !== "undefined");
@@ -84,7 +88,7 @@ if (isUsingConfig){
     }
 } else {
     if (typeof argv.filename === "undefined") {
-        console.error('No filename provided! Please provide a filename via -f');
+        yargs.showHelp();
         return -1;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-static-html",
-  "version": "1.2.0",
+  "version": "1.3.1",
   "description": "Turn your Elm app into a static HTML site",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Updated the README from `--init` to `--init-config`. Now outputs the usage
message if an invalid command was passed, or when run with zero arguments.
added a version flag to be more unix like.