### PR TITLE
Accept multiple output/viewFunction pairs per elm file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ The config file looks like this:
 }
 ```
 
+To generate multiple output files from a single elm file, supply an array of outputFile/viewFunction pairs:
+
+```js
+{
+	"files": {
+		"<ElmFile.elm>": [{
+			"output": "<OutputFile.html>",
+			"viewFunction": "view"
+		}, {
+			"output": "<AnotherOutputFile.html>",
+			"viewFunction": "anotherView"
+		}]
+	}
+}
+```
 
 ## Notes
 

--- a/templates.js
+++ b/templates.js
@@ -18,9 +18,12 @@ var importLines = function(moduleNames){
 };
 
 var viewFunctions = function(moduleNames){
-    return moduleNames.map(function(moduleConfig){
-        return `("${moduleConfig.output}", ${moduleConfig.moduleName}.${moduleConfig.func})`;
-    });
+    var pairs = moduleNames.map(function(moduleConfig){
+            return moduleConfig.outputsAndFuncs.map(function(outputConfig){
+                return `("${outputConfig.output}", ${moduleConfig.moduleName}.${outputConfig.viewFunction})`;
+            });
+        });
+    return [].concat.apply([], pairs);
 };
 
 // this is our render's file contents


### PR DESCRIPTION
Turning one elm file into multiple html files.

The values of the `files` object can now be either a single output/viewFunction pair, or an array of them. That means this change is fully backwards-compatible. 